### PR TITLE
Import Iterable from collections.abc

### DIFF
--- a/reframed/cobra/simulation.py
+++ b/reframed/cobra/simulation.py
@@ -3,7 +3,7 @@ from ..solvers.solver import VarType
 from ..solvers.solution import Status
 from ..core.model import ReactionType
 from warnings import warn
-from collections import Iterable
+from collections.abc import Iterable
 from math import inf
 
 


### PR DESCRIPTION
This fixes an import that has been deprecated since python version 3.3 and is no longer supported in version 3.10.0.